### PR TITLE
Wire localized copy into home and use-case views

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,32 +1,36 @@
 ---
-const ADDRESS_LINE =
-  '17, Gukjegeumyung-ro 2-gil, Yeongdeungpo-gu, Seoul, Republic of Korea';
-const BIZ_NUM = '678-87-02665';
+import { FALLBACK_LOCALE, getTranslations, type SupportedLocale } from "../i18n";
+
+const locale = (Astro.currentLocale ?? FALLBACK_LOCALE) as SupportedLocale;
+const translations = getTranslations(locale);
+const footer = translations.home.footer ?? translations.useCases.footer;
+const topLabel = footer.top.replace('▲', '').trim();
+const showArrow = footer.top.includes('▲');
 ---
 
 <footer class="footer" data-component="footer">
   <div class="container">
     <!-- Brand (right on desktop/tablet, centered on mobile) -->
-    <div class="brand">
-      <span>Billycrew</span>
-      <span class="sep" aria-hidden="true">|</span>
-      <span>Kuanta Solution</span>
-      <img src="/logo/Kuanta.svg" alt="Kuanta" class="logo" />
-    </div>
+      <div class="brand">
+        <span>{footer.companyName}</span>
+        <span class="sep" aria-hidden="true">|</span>
+        <span>{footer.productName}</span>
+        <img src="/logo/Kuanta.svg" alt="Kuanta" class="logo" />
+      </div>
 
-    <!-- Address (pairs with brand) -->
-    <address class="addr" aria-label="Address">
-      <div class="addr__line">{ADDRESS_LINE}</div>
-      <div class="addr__biz">Business Registration Number : {BIZ_NUM}</div>
-    </address>
+      <!-- Address (pairs with brand) -->
+      <address class="addr" aria-label="Address">
+        <div class="addr__line">{footer.address}</div>
+        <div class="addr__biz">{footer.businessRegistrationNumber}</div>
+      </address>
 
-    <!-- TOP ▲ with vertical separators -->
-    <button class="to-top" aria-label="Back to top">
-      <span>TOP</span> <span class="arrow">▲</span>
-    </button>
+      <!-- TOP ▲ with vertical separators -->
+      <button class="to-top" aria-label="Back to top">
+        <span>{topLabel}</span> {showArrow && <span class="arrow">▲</span>}
+      </button>
 
-    <!-- Copyright -->
-    <small class="copy">© billycrew 2023. All Rights Reserved.</small>
+      <!-- Copyright -->
+      <small class="copy">{footer.rights}</small>
   </div>
 
   <script type="module">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,20 +2,25 @@
 /** <Header /> — i18n-ready (EN/KO) */
 import { getRelativeLocaleUrl } from "astro:i18n";
 
+import { FALLBACK_LOCALE, getTranslations, type SupportedLocale } from "../i18n";
+
+const locale = (Astro.currentLocale ?? FALLBACK_LOCALE) as SupportedLocale;
+const t = getTranslations(locale);
+
 const LINKS = [
-  { label: 'Get started', href: '/get-started' },
-  { label: 'Docs',        href: '/docs' },
-  { label: 'Product',     href: '/product' },
-  { label: 'Use Cases',   href: '/use-cases' },
-  { label: 'Blog',        href: '/blog' }
+  { label: t.nav.getStarted, href: '/get-started' },
+  { label: t.nav.docs,        href: '/docs' },
+  { label: t.nav.product,     href: '/product' },
+  { label: t.nav.useCases,    href: '/use-cases' },
+  { label: t.nav.blog,        href: '/blog' }
 ] as const;
 
 const LANGS = [
-  { code: 'en', label: 'ENG', flag: '🇺🇸' },
-  { code: 'ko', label: 'KOR', flag: '🇰🇷' }
+  { code: 'en', label: t.nav.language.en, flag: '🇺🇸' },
+  { code: 'ko', label: t.nav.language.ko, flag: '🇰🇷' }
 ] as const;
 
-const CURRENT_LANG = Astro.currentLocale ?? 'en';
+const CURRENT_LANG = locale;
 const here = Astro.url.pathname;
 
 // 1) Remove any existing locale prefix (/en if you ever prefix it, /ko today)
@@ -51,7 +56,7 @@ const drawerId = 'hdr-drawer';
     <!-- Right: actions -->
     <div class="actions">
       <a class="download action" href={L('/download')}>
-        <span>Download</span>
+        <span>{t.nav.download}</span>
         <!-- your provided SVG -->
         <svg class="dl-ic" width="13" height="12" viewBox="0 0 13 12" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <g clip-path="url(#clip0_572_5523)">
@@ -129,7 +134,7 @@ const drawerId = 'hdr-drawer';
 
     <div class="drawer__section">
       <a class="download action" href={L('/download')}>
-        <span>Download</span>
+        <span>{t.nav.download}</span>
         <!-- same SVG as above -->
         <svg class="dl-ic" width="13" height="12" viewBox="0 0 13 12" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><g clip-path="url(#clip0_572_5523)"><path d="M10.5371 6.28484H11.1071V11.4261H11.6771V6.28484H12.2509V5.71484H10.5371V6.28484Z" fill="#646471"/><path d="M11.6755 0.570312H11.1055V2.28406H11.6755V0.570312Z" fill="#646471"/><path d="M11.6755 3.42773H11.1055V5.14148H11.6755V3.42773Z" fill="#646471"/><path d="M11.107 11.4258H1.39453V11.9995H11.107V11.4258Z" fill="#646471"/><path d="M11.1063 0H9.39258V0.57H11.1063V0Z" fill="#646471"/><path d="M9.96211 5.71484H8.81836V6.28484H9.96211V5.71484Z" fill="#646471"/><path d="M8.2493 7.42898V3.42773H4.24805V3.99773H4.8218V4.57148H5.3918V5.14148H4.8218V5.71523H4.24805V7.42898H4.8218V8.56898H5.3918V9.14273H7.6793V8.56898H6.53555V7.99898H5.96555V6.85523H6.53555V6.28523H7.10555V6.85523H7.6793V7.42898H8.2493Z" fill="#646471"/><path d="M8.24891 0H6.53516V0.57H8.24891V0Z" fill="#646471"/><path d="M5.96555 0H4.24805V0.57H5.96555V0Z" fill="#646471"/><path d="M3.67695 5.71484H2.5332V6.28484H3.67695V5.71484Z" fill="#646471"/><path d="M3.10828 0H1.39453V0.57H3.10828V0Z" fill="#646471"/><path d="M1.39406 0.570312H0.820312V2.28406H1.39406V0.570312Z" fill="#646471"/><path d="M1.39406 3.42773H0.820312V5.14148H1.39406V3.42773Z" fill="#646471"/><path d="M1.96375 6.28484V5.71484H0.25V6.28484H0.82V11.4261H1.39375V6.28484H1.96375Z" fill="#646471"/></g><defs><clipPath id="clip0_572_5523"><rect width="12" height="12" fill="white" transform="translate(0.25)"/></clipPath></defs></svg>
       </a>

--- a/src/components/News.astro
+++ b/src/components/News.astro
@@ -1,198 +1,216 @@
 ---
 import { getCollection } from 'astro:content';
 
-const posts = (await getCollection('blog'))
-	.filter(post => post.data.draft === false).sort(
-	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
-).slice(0, 3);
+import { FALLBACK_LOCALE, getTranslations, type SupportedLocale } from "../i18n";
 
-console.log(JSON.stringify(posts[0].data));
+const posts = (await getCollection('blog'))
+  .filter((post) => post.data.draft === false)
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+  .slice(0, 3);
 
 const SITE_URL = import.meta.env.SITE_URL || 'http://localhost:4321';
 
+const locale = (Astro.currentLocale ?? FALLBACK_LOCALE) as SupportedLocale;
+const news = getTranslations(locale).home.news;
+
+const hasPosts = posts.length > 0;
 ---
 <section class="cards-section" aria-labelledby="news-title">
-  <!-- <div class="container"> -->
-    <h2 id="news-title" class="news-title">
-      NEWS / BLOG
-    </h2>
-  <!-- </div> -->
+  <h2 id="news-title" class="news-title">{news.title}</h2>
 
-  
-	<ul>
-		{
-			posts.map((post) => (
-				<li>
-					<a href={`${SITE_URL}/blog/${post.id}/`}>
-						<img width={720} height={360} src={`${post.data.heroImage?.src}`} alt="" />
-						<div class="text-container">
-							<h4 class="title">{post.data.title}</h4>
+  {hasPosts ? (
+    <ul>
+      {posts.map((post) => (
+        <li>
+          <a href={`${SITE_URL}/blog/${post.id}/`}>
+            <img width={720} height={360} src={`${post.data.heroImage?.src}`} alt="" />
+            <div class="text-container">
+              <h4 class="title">{post.data.title}</h4>
               <p class="description">{post.data.description}</p>
-              <p class="read-more">Read more →</p>
-						</div>
-					</a>
-				</li>
-			))
-		}
-	</ul>
+              <p class="read-more">{news.cards.cta} →</p>
+            </div>
+          </a>
+        </li>
+      ))}
+    </ul>
+  ) : (
+    <div class="placeholder">
+      <h3 class="placeholder__headline">{news.cards.headline}</h3>
+      <p class="placeholder__desc">{news.cards.description}</p>
+      <a class="placeholder__cta" href="#">{news.cards.cta} →</a>
+    </div>
+  )}
 </section>
 
 <style>
-  .cards-section{ display: flex;
+  .cards-section{
+    display: flex;
     padding: 120px 36px;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     gap: 32px;
     align-self: stretch;
-    background: linear-gradient(73deg, rgba(81, 111, 233, 0.40) 9.74%, rgba(152, 223, 165, 0.13) 98.3%); 
-  } 
-
-  .container{
-    width: min(1200px, 100%);
-    margin-inline: auto;
-    padding-inline: 20px;
+    background: linear-gradient(73deg, rgba(81, 111, 233, 0.40) 9.74%, rgba(152, 223, 165, 0.13) 98.3%);
   }
-  @media (min-width: 768px){ .container{ padding-inline: 32px; } }
-  @media (min-width:1024px){ .container{ padding-inline: 50px; } }
 
-  /* Heading (your spec) */
   .news-title{
     color: #4A3BFF;
     font-family: Inter;
     font-size: clamp(30px, 9vw, 75px);
     font-style: italic;
     font-weight: 900;
-    line-height: 110%; /* 82.5px */
+    line-height: 110%;
     letter-spacing: -0.75px;
     text-transform: uppercase;
-    margin-left: 25px;
-    margin-bottom: 50px;
+    margin: 0;
+    text-align: center;
   }
-  
 
+  ul{
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    justify-content: center;
+  }
 
-	ul {
-		width: 100%;
-		display: flex;
-		flex-wrap: wrap;
-		gap: 2rem;
-		list-style-type: none;
-		margin: 0;
-		padding: 0;
-		justify-content: center;
-	}
-
-	ul li {
-		width: calc(33.3% - 2rem);
-		box-sizing: border-box;
+  ul li{
+    width: calc(33.3% - 2rem);
+    box-sizing: border-box;
     border-radius: 4px;
     border: 1px solid rgba(0, 0, 0, 0.10);
     background: #FDFDFF;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.02), 0 6px 12px 0 rgba(0, 0, 0, 0.03);
-		flex: none;
-		order: 0;
-		flex-grow: 0;
-		display: flex;
-		flex-direction: column;
-	}
+    display: flex;
+    flex-direction: column;
+  }
 
-	ul li:last-child {
-		gap: 0; 
-	}
+  ul li *{
+    text-decoration: none;
+    transition: 0.2s ease;
+  }
 
-	ul li * {
-		text-decoration: none;
-		transition: 0.2s ease;
-	}
+  ul li img{
+    width: 100%;
+    height: 302px;
+    object-fit: cover;
+    border-bottom-right-radius: 0px;
+    border-bottom-left-radius: 0px;
+    border-top-right-radius: 4px;
+    border-top-left-radius: 4px;
+  }
 
-	ul li img {
-		width: 100%;
-		height: 302px;
-		object-fit: cover;
-		border-bottom-right-radius: 0px;
-		border-bottom-left-radius: 0px;
-		border-top-right-radius: 4px;
-		border-top-left-radius: 4px;
-		flex: none;
-		order: 0;
-		align-self: stretch;
-	}
+  ul li a{
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
 
-	ul li a {
-		display: flex;
-		flex-direction: column;
-		height: 100%;
-	}
+  .text-container{
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    margin-top: 10px;
+    padding: 24px;
+  }
 
-	.text-container {
-		flex-grow: 1;
-		display: flex;
-		flex-direction: column;
-		justify-content: flex-start;
-		margin-top: 10px;
-		padding: 24px;
-	}
-
-	.date {
-		margin: 0;
-		color: rgb(var(--gray));
-		font-size: 14px;
-		line-height: 1.5;
-	}
-
-
-	.read-more {
+  .read-more{
     color: #000C4A;
     font-family: Inter;
     font-size: 18px;
     font-style: italic;
     font-weight: 700;
-    line-height: 145%; /* 26.1px */
+    line-height: 145%;
     letter-spacing: -0.09px;
     margin-top: 32px;
     margin-bottom: 0;
-	}
+  }
 
-
-	.description {
+  .description{
     color: #646471;
-    font-family: "VITRO CORE",;
+    font-family: "VITRO CORE";
     font-size: 14px;
     font-style: normal;
     font-weight: 900;
-    line-height: 150%; /* 21px */
+    line-height: 150%;
     letter-spacing: -0.14px;
     margin: 0;
-	}
+  }
 
-	.title {
+  .title{
     color: #000C4A;
-    font-family: "VITRO CORE"
+    font-family: "VITRO CORE";
     font-size: 24px;
     font-style: normal;
     font-weight: 900;
-    line-height: 145%; /* 34.8px */
+    line-height: 145%;
     letter-spacing: -0.48px;
     margin: 0;
-	}
+  }
 
-	
+  ul a:hover img{ box-shadow: var(--box-shadow); }
 
-	ul a:hover img {
-		box-shadow: var(--box-shadow);
-	}
+  .placeholder{
+    width: 100%;
+    max-width: 480px;
+    margin: 0 auto;
+    text-align: center;
+    border-radius: 16px;
+    border: 1px dashed rgba(0,0,0,0.15);
+    background: rgba(255,255,255,0.65);
+    padding: 32px 24px;
+  }
 
-	@media (max-width: 720px) {
-		.recommended {
-			width: calc(100vw - 60px);
-		}
-		ul {
-			gap: 0.5em;
-		}
-		ul li {
-			width: 100%;
-			text-align: center;
-		}
-	}
+  .placeholder__headline{
+    margin: 0 0 12px;
+    color: #000C4A;
+    font-family: "VITRO CORE";
+    font-size: clamp(20px, 4vw, 28px);
+    font-weight: 900;
+    line-height: 1.4;
+    letter-spacing: -0.4px;
+    text-transform: uppercase;
+  }
 
+  .placeholder__desc{
+    margin: 0 0 18px;
+    color: #646471;
+    font-family: "VITRO CORE";
+    font-size: clamp(14px, 3.4vw, 16px);
+    font-weight: 900;
+    line-height: 1.5;
+    letter-spacing: -0.14px;
+  }
+
+  .placeholder__cta{
+    display: inline-block;
+    padding: 10px 22px;
+    border-radius: 999px;
+    background: #000C4A;
+    color: #fff;
+    font-family: Inter;
+    font-size: 15px;
+    font-style: italic;
+    font-weight: 700;
+    letter-spacing: -0.05em;
+    text-decoration: none;
+  }
+
+  @media (max-width: 1024px){
+    ul li{ width: calc(50% - 1.5rem); }
+  }
+
+  @media (max-width: 720px){
+    ul{
+      gap: 0.5em;
+    }
+    ul li{
+      width: 100%;
+      text-align: center;
+    }
+  }
 </style>

--- a/src/components/home/Cards.astro
+++ b/src/components/home/Cards.astro
@@ -1,13 +1,15 @@
 ---
 /* 3-card section; uses your images and typography */
+import { FALLBACK_LOCALE, getTranslations, type SupportedLocale } from "../../i18n";
+
+const locale = (Astro.currentLocale ?? FALLBACK_LOCALE) as SupportedLocale;
+const translations = getTranslations(locale);
+const cards = translations.home.cards;
+const heroTagline = translations.home.hero.subTagline;
 ---
 <section class="cards-section" aria-labelledby="cards-title">
   <div class="container">
-    <h2 id="cards-title" class="cards-title">
-      Low-Latency and High-Performance,<br />
-      Yet Programmable,<br />
-      Making it Flexible.
-    </h2>
+    <h2 id="cards-title" class="cards-title">{heroTagline}</h2>
   </div>
 
   <div class="container">
@@ -17,12 +19,9 @@
         <article class="card">
           <img class="card__img" src="/images/home/pmr.jpg" alt="PMR preview" />
           <div class="card__body">
-            <h3 class="card__title">PMR</h3>
-            <p class="card__desc">
-              Flexible configuration schemes and programming interfaces allow you to design a single
-              message architecture that responds consistently to all messages.
-            </p>
-            <a class="card__more" href="#">Read more →</a>
+            <h3 class="card__title">{cards.pmr.title}</h3>
+            <p class="card__desc">{cards.pmr.description}</p>
+            <a class="card__more" href="#">{cards.pmr.cta} →</a>
           </div>
         </article>
 
@@ -30,12 +29,9 @@
         <article class="card">
           <img class="card__img" src="/images/home/kas.jpg" alt="KAS preview" />
           <div class="card__body">
-            <h3 class="card__title">KAS</h3>
-            <p class="card__desc">
-              A micro-application service that supports vertical/horizontal unit business expansion
-              without restrictions on cloud and on-premises.
-            </p>
-            <a class="card__more" href="#">Read more →</a>
+            <h3 class="card__title">{cards.kas.title}</h3>
+            <p class="card__desc">{cards.kas.description}</p>
+            <a class="card__more" href="#">{cards.kas.cta} →</a>
           </div>
         </article>
 
@@ -43,12 +39,9 @@
         <article class="card">
           <img class="card__img" src="/images/home/broker.jpg" alt="Broker preview" />
           <div class="card__body">
-            <h3 class="card__title">BROKER</h3>
-            <p class="card__desc">
-              A Pub/Sub-based message broker supporting diverse topologies, high-speed messaging
-              processing, and reliable recovery and retransmission.
-            </p>
-            <a class="card__more" href="#">Read more →</a>
+            <h3 class="card__title">{cards.broker.title}</h3>
+            <p class="card__desc">{cards.broker.description}</p>
+            <a class="card__more" href="#">{cards.broker.cta} →</a>
           </div>
         </article>
       </div>

--- a/src/components/home/Features.astro
+++ b/src/components/home/Features.astro
@@ -1,17 +1,15 @@
 ---
 /* 3-card section; uses your images and typography */
+import { FALLBACK_LOCALE, getTranslations, type SupportedLocale } from "../../i18n";
+
+const locale = (Astro.currentLocale ?? FALLBACK_LOCALE) as SupportedLocale;
+const features = getTranslations(locale).home.features;
 ---
 <section class="cards-section" aria-labelledby="cards-title">
   <div class="container">
-    <h2 id="cards-title" class="cards-title">
-      Features
-    </h2>
-    <h2 class="cards-subtitle">
-      Technology that Leads the Way for Challenging Environments
-    </h2>
-    <h5 class="main-desc">
-      Learn about the core features of Kuanta technology, which offers stability and superior technology even in a rapidly changing market environment, a consistent messaging architecture, and flexible application across diverse environments without constraints. You can immediately apply it to your service environment.
-    </h5>
+    <h2 id="cards-title" class="cards-title">{features.title}</h2>
+    <h2 class="cards-subtitle">{features.tagline}</h2>
+    <h5 class="main-desc">{features.description}</h5>
   </div>
 
   <div class="container">
@@ -28,10 +26,8 @@
             </defs>
           </svg>
         </div>
-        <h3 class="feature-title">Engineer-friendly</h3>
-        <p class="feature-desc">
-          Intuitive CLI and TUI for engineers Fast and accurate operations
-        </p>
+        <h3 class="feature-title">{features.items.engineerFriendly.title}</h3>
+        <p class="feature-desc">{features.items.engineerFriendly.description}</p>
       </article>
 
       <article class="feature-card" role="listitem">
@@ -46,10 +42,8 @@
             </defs>
           </svg>
         </div>
-        <h3 class="feature-title">Integrierte with existing systems</h3>
-        <p class="feature-desc">
-          Flexible integration with various legacy and external systems
-        </p>
+        <h3 class="feature-title">{features.items.integrateExisting.title}</h3>
+        <p class="feature-desc">{features.items.integrateExisting.description}</p>
       </article>
 
       <article class="feature-card" role="listitem">
@@ -64,10 +58,8 @@
             </defs>
           </svg>
         </div>
-        <h3 class="feature-title">Message analysis and statistics</h3>
-        <p class="feature-desc">
-          Analyze collected and refined, reliable real-time data
-        </p>
+        <h3 class="feature-title">{features.items.messageAnalysis.title}</h3>
+        <p class="feature-desc">{features.items.messageAnalysis.description}</p>
       </article>
 
       <article class="feature-card" role="listitem">
@@ -82,10 +74,8 @@
             </defs>
           </svg>
         </div>
-        <h3 class="feature-title">Hierarchical distribution & low-latency messaging</h3>
-        <p class="feature-desc">
-          Fast and reliable delivery through system-wide technology
-        </p>
+        <h3 class="feature-title">{features.items.hierarchicalDistribution.title}</h3>
+        <p class="feature-desc">{features.items.hierarchicalDistribution.description}</p>
       </article>
     </div>
   </div>

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -1,18 +1,18 @@
 ---
 /* No props for now; uses the fixed copy & image you provided */
+import { FALLBACK_LOCALE, getTranslations, type SupportedLocale } from "../../i18n";
+
+const locale = (Astro.currentLocale ?? FALLBACK_LOCALE) as SupportedLocale;
+const hero = getTranslations(locale).home.hero;
 ---
 <section class="home-hero" aria-labelledby="home-hero-title">
   <div class="hero__inner">
     <h1 id="home-hero-title" class="hero__title">
-      PROGRAMMABLE <br /> MESSAGE <br /> ROUTER
+      {hero.title}
     </h1>
 
-    <p class="hero__desc">
-      Kuanta PMR helps you solve integration problems by immediately applying best
-      practices through the latest message patterns derived from microservice architecture.
-      The new low-latency architecture and programmable messaging environment can actively
-      respond to any integration and deployment strategy required.
-    </p>
+    <p class="hero__desc">{hero.description}</p>
+    <p class="hero__tagline">{hero.subTagline}</p>
   </div>
 </section>
 
@@ -96,11 +96,27 @@
   text-wrap: balance;
 }
 
+.hero__tagline{
+  margin: 0;
+  color: rgba(253,253,255,0.85);
+  font-family: "Vitro Core", Inter, system-ui, sans-serif;
+  font-size: clamp(14px, 3vw, 20px);
+  font-style: italic;
+  font-weight: 700;
+  line-height: 1.45;
+  letter-spacing: -0.01em;
+  max-inline-size: 60ch;
+  text-align: center;
+}
+
 /* Tablet+ */
 @media (min-width: 768px){
   .hero__desc{
     font-size: clamp(16px, 2.2vw, 20px);
     line-height: 1.45;
+  }
+  .hero__tagline{
+    font-size: clamp(15px, 2.1vw, 18px);
   }
 }
 
@@ -113,6 +129,7 @@
     padding-block: clamp(48px, 6vw, 96px);
   }
   .hero__title{ max-inline-size: 12ch; }
+  .hero__tagline{ text-align: left; }
 }
 
 /* Safety for full-bleed */

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,20 @@
+import en from './locale_en.json';
+import ko from './locale_ko.json';
+
+const dictionaries = {
+  en,
+  ko,
+} as const;
+
+export type SupportedLocale = keyof typeof dictionaries;
+export type Translations = (typeof dictionaries)[SupportedLocale];
+
+export const FALLBACK_LOCALE: SupportedLocale = 'en';
+
+export function getTranslations(locale: string | undefined): Translations {
+  if (locale && locale in dictionaries) {
+    return dictionaries[locale as SupportedLocale];
+  }
+
+  return dictionaries[FALLBACK_LOCALE];
+}

--- a/src/i18n/locale_en.json
+++ b/src/i18n/locale_en.json
@@ -20,46 +20,46 @@
   "home": {
     "hero": {
       "title": "PROGRAMMABLE MESSAGE ROUTER",
-      "description": "Kuanta PMR helps you solve integration problems by immediately applying best practices through the latest message patterns derived from microservice architecture. The new low‑latency architecture and programmable messaging environment can actively respond to any integration and deployment strategy required.",
-      "subTagline": "Low‑Latency and High‑Performance, Yet Programmable, Making it Flexible."
+      "description": "Kuanta PMR helps you resolve integration challenges by applying best practices drawn from the latest microservice messaging patterns. Its low-latency architecture and programmable messaging environment adapt seamlessly to any integration or deployment strategy you need.",
+      "subTagline": "Low latency and high performance, with the flexibility of full programmability."
     },
     "cards": {
       "pmr": {
         "title": "PMR",
-        "description": "Flexible configuration schemes and programming interfaces allow you to design a single message architecture that responds consistently to all messages.",
+        "description": "Flexible configuration schemes and programming interfaces let you design a unified messaging architecture that responds consistently to every message.",
         "cta": "Read more"
       },
       "kas": {
         "title": "KAS",
-        "description": "A micro‑application service that supports vertical/horizontal unit business expansion without restrictions on cloud and on‑premises.",
+        "description": "A micro-application service that supports vertical and horizontal business expansion without cloud or on-premises restrictions.",
         "cta": "Read more"
       },
       "broker": {
         "title": "BROKER",
-        "description": "A Pub/Sub‑based message broker supporting diverse topologies, high‑speed messaging processing, and reliable recovery and retransmission. Configure your message broker to suit your needs.",
+        "description": "A Pub/Sub-based message broker with flexible topology support, high-speed processing, and reliable recovery and retransmission. Configure the broker precisely to your needs.",
         "cta": "Read more"
       }
     },
     "features": {
       "title": "Features",
-      "tagline": "Technology That Lead The Way For Challenging Environments",
-      "description": "Learn about the core features of Kuanta technology, which offers stability and superior technology even in a rapidly changing market environment, a consistent messaging architecture, and flexible application across diverse environments without constraints. You can immediately apply it to your service environment.",
+      "tagline": "Technology that leads the way in challenging environments",
+      "description": "Explore the core features of Kuanta technology: dependable performance in fast-changing markets, a consistent messaging architecture, and flexible deployment across diverse environments without constraints. Apply it to your service landscape right away.",
       "items": {
         "engineerFriendly": {
-          "title": "Engineer‑friendly",
-          "description": "Intuitive CLI and TUI for engineers\nFast and accurate operations"
+          "title": "Engineer-friendly",
+          "description": "Intuitive CLI and TUI for engineers\nFast, accurate operations"
         },
         "integrateExisting": {
           "title": "Integrate with existing systems",
-          "description": "Flexible integration with various legacy and external systems"
+          "description": "Flexible integration with diverse legacy and external systems"
         },
         "messageAnalysis": {
           "title": "Message analysis and statistics",
-          "description": "Analyze collected and refined, reliable real‑time data"
+          "description": "Analyze curated, reliable real-time data"
         },
         "hierarchicalDistribution": {
-          "title": "Hierarchical distribution & low‑latency messaging",
-          "description": "Fast and reliable delivery through system‑wide technology"
+          "title": "Hierarchical distribution & low-latency messaging",
+          "description": "Deliver messages quickly and reliably with system-wide technology"
         }
       }
     },
@@ -68,7 +68,7 @@
       "cards": {
         "headline": "EFFICIENT TRADING SOLUTIONS",
         "title": "Title",
-        "description": "Call out a feature, benefit, or value of your site or product that can stand on its own.",
+        "description": "Highlight a feature, benefit, or value of your site or product that stands strong on its own.",
         "cta": "Read more"
       }
     },
@@ -76,9 +76,9 @@
       "companyName": "Billycrew",
       "productName": "Kuanta Solution",
       "brand": "Kuanta",
-      "address": "17, Gukjegeumyung‑ro 2‑gil, Yeongdeungpo‑gu, Seoul, Republic of Korea",
-      "businessRegistrationNumber": "678‑87‑02665",
-      "rights": "© billycrew 2023. All Rights Reserved.",
+      "address": "17, Gukjegeumyung-ro 2-gil, Yeongdeungpo-gu, Seoul, Republic of Korea",
+      "businessRegistrationNumber": "678-87-02665",
+      "rights": "© billycrew 2023. All rights reserved.",
       "top": "TOP ▲"
     }
   },
@@ -88,21 +88,21 @@
     },
     "case1": {
       "title": "Daishin Securities Kuanta Solutions",
-      "description": "Discover Kuanta’s Features, built with reliable and advanced architecture for volatile markets, offering a consistent single messaging framework and flexible deployment. Learn more about the core functions of Kuanta technology.",
+      "description": "Discover Kuanta’s capabilities: robust, advanced architecture for volatile markets, a consistent single messaging framework, and flexible deployment. Learn more about the core functions of Kuanta technology.",
       "cta": "Learn"
     },
     "case2": {
       "title": "WOORI INVESTMENT SECURITIES Kuanta Solutions",
-      "description": "Discover Kuanta’s Features, built with reliable and advanced architecture for volatile markets, offering a consistent single messaging framework and flexible deployment. Learn more about the core functions of Kuanta technology.",
+      "description": "Explore Kuanta’s capabilities: resilient architecture for volatile markets, a unified messaging framework, and flexible deployment. Learn more about the core functions of Kuanta technology.",
       "cta": "Learn"
     },
     "footer": {
       "companyName": "Billycrew",
       "productName": "Kuanta Solution",
       "brand": "Kuanta",
-      "address": "17, Gukjegeumyung‑ro 2‑gil, Yeongdeungpo‑gu, Seoul, Republic of Korea",
-      "businessRegistrationNumber": "678‑87‑02665",
-      "rights": "© billycrew 2023. All Rights Reserved.",
+      "address": "17, Gukjegeumyung-ro 2-gil, Yeongdeungpo-gu, Seoul, Republic of Korea",
+      "businessRegistrationNumber": "678-87-02665",
+      "rights": "© billycrew 2023. All rights reserved.",
       "top": "TOP ▲"
     }
   }

--- a/src/i18n/locale_ko.json
+++ b/src/i18n/locale_ko.json
@@ -9,7 +9,7 @@
       "broker": "BROKER",
       "kc": "KC"
     },
-    "useCases": "사례 사례",
+    "useCases": "활용 사례",
     "blog": "블로그",
     "download": "다운로드",
     "language": {
@@ -20,46 +20,46 @@
   "home": {
     "hero": {
       "title": "PROGRAMMABLE MESSAGE ROUTER",
-      "description": "마이크로 서비스 아키텍처에서 비롯된 최신 메시지 패턴을 통해 베스트 프랙티스를 즉시 적용하여 통합 문제를 해결할 수 있도록 도와줍니다. 새로운 저지연 아키텍처와 프로그래밍 가능한 메시징 환경은 어떤 통합 및 배포 전략에도 적극적으로 대응할 수 있습니다.",
-      "subTagline": "저지연과 고성능, 그리고 프로그래밍 가능한 환경으로 인해 메시징에 유연성을 제공합니다."
+      "description": "마이크로서비스 아키텍처에서 도출한 최신 메시지 패턴을 적용하여 통합 문제를 빠르게 해결하도록 돕습니다. 저지연 아키텍처와 프로그래밍 가능한 메시징 환경이 요구되는 모든 통합 및 배포 전략에 유연하게 대응합니다.",
+      "subTagline": "저지연·고성능 기반에 완전한 프로그래밍 유연성을 더했습니다."
     },
     "cards": {
       "pmr": {
         "title": "PMR",
-        "description": "유연한 설정 체계와 프로그래밍 인터페이스를 통해 모든 메시지에 일관되게 반응하는 단일 메시징 아키텍처를 설계할 수 있습니다.",
-        "cta": "Read more"
+        "description": "유연한 설정 체계와 프로그래밍 인터페이스로 모든 메시지에 일관되게 반응하는 단일 메시징 아키텍처를 설계할 수 있습니다.",
+        "cta": "자세히 보기"
       },
       "kas": {
         "title": "KAS",
-        "description": "수직/수평 단위 업무 확장을 제한 없이 지원하는 마이크로 애플리케이션 서비스로, 클라우드와 온프레미스에서 제약 없이 확장할 수 있습니다.",
-        "cta": "Read more"
+        "description": "수직·수평 단위 업무 확장을 제한 없이 지원하는 마이크로 애플리케이션 서비스로, 클라우드와 온프레미스 환경을 가리지 않고 확장할 수 있습니다.",
+        "cta": "자세히 보기"
       },
       "broker": {
         "title": "BROKER",
-        "description": "다양한 토폴로지, 고속 메시징 처리, 안정적인 복구와 재전송을 지원하는 Pub/Sub 기반 메시지 브로커입니다. 메시지 브로커를 필요에 맞게 구성하세요.",
-        "cta": "Read more"
+        "description": "다양한 토폴로지와 고속 메시징 처리, 안정적인 복구 및 재전송을 지원하는 Pub/Sub 기반 메시지 브로커입니다. 원하는 방식으로 메시지 브로커를 구성하세요.",
+        "cta": "자세히 보기"
       }
     },
     "features": {
       "title": "핵심 기능",
-      "tagline": "Technology That Lead The Way For Challenging Environments",
-      "description": "급변하는 시장 환경에서도 안정적이고 우수한 기술력으로, 일관된 메시징 아키텍처와 다양한 환경에서도 제약 없이 적용할 수 있는 유연한 쿠안타 기술의 핵심 기능에 대해 알아보세요. 서비스 환경에도 즉시 적용할 수 있습니다.",
+      "tagline": "도전적인 환경을 선도하는 기술",
+      "description": "급변하는 시장에서도 안정성과 우수한 기술력을 제공하는 쿠안타의 핵심 기능을 확인해 보세요. 일관된 메시징 아키텍처와 다양한 환경에 제약 없는 유연한 적용으로, 서비스 현장에 즉시 활용할 수 있습니다.",
       "items": {
         "engineerFriendly": {
           "title": "엔지니어 친화적",
-          "description": "엔지니어를 위한 직관적인 CLI 및 TUI\n빠르고 정확한 서비스 운영 제공"
+          "description": "엔지니어를 위한 직관적인 CLI·TUI 제공\n빠르고 정확한 서비스 운영"
         },
         "integrateExisting": {
           "title": "기존 시스템과 통합",
-          "description": "다양한 레거시 및 외부 시스템과의 유연한 연동으로 일관된 운영 환경 구축"
+          "description": "다양한 레거시·외부 시스템과 유연하게 연동하여 일관된 운영 환경 구현"
         },
         "messageAnalysis": {
           "title": "메시지 분석 및 통계",
-          "description": "수집된 데이터를 분석하여 신뢰성 높은 실시간 데이터를 제공합니다"
+          "description": "정제된 데이터를 분석하여 신뢰성 높은 실시간 정보를 제공합니다"
         },
         "hierarchicalDistribution": {
           "title": "계층적 배포 & 저지연 메시징",
-          "description": "시스템 전반에 걸친 계층적 메시징 기술을 통해 빠르고 안정적인 메시징을 제공합니다"
+          "description": "시스템 전반의 계층적 메시징 기술로 빠르고 안정적인 전달을 실현합니다"
         }
       }
     },
@@ -68,8 +68,8 @@
       "cards": {
         "headline": "EFFICIENT TRADING SOLUTIONS",
         "title": "기사 제목",
-        "description": "블록체인 기술이 서비스의 효율성을 크게 향상할 수 있는 기능, 예제 또는 텍스트를 강조하세요.",
-        "cta": "Read more"
+        "description": "서비스나 제품이 지닌 기능과 가치를 강조하는 콘텐츠를 소개하세요.",
+        "cta": "자세히 보기"
       }
     },
     "footer": {
@@ -78,7 +78,7 @@
       "brand": "Kuanta",
       "address": "서울특별시 영등포구 국제금융2길 17, 6층 608호 (여의도동, 시티플라자)",
       "businessRegistrationNumber": "678-87-02665",
-      "rights": "© billycrew 2023. All Rights Reserved.",
+      "rights": "© billycrew 2023. All rights reserved.",
       "top": "TOP ▲"
     }
   },
@@ -88,13 +88,13 @@
     },
     "case1": {
       "title": "대신증권 Kuanta 솔루션",
-      "description": "변동성이 큰 시장에서도 안정적이고 우수한 기술력으로, 일관된 단일 메시징 아키텍처와 다양한 환경에서도 유연한 쿠안타 기술의 핵심 기능에 대해 알아보세요.",
-      "cta": "Learn"
+      "description": "변동성이 큰 시장에서도 안정적이고 우수한 기술력으로, 일관된 단일 메시징 아키텍처와 다양한 환경에서 유연하게 활용할 수 있는 쿠안타 기술의 핵심 기능을 확인해 보세요.",
+      "cta": "자세히 알아보기"
     },
     "case2": {
       "title": "우리투자증권 Kuanta 솔루션",
-      "description": "변동성이 큰 시장에서도 안정적이고 우수한 기술력으로, 일관된 단일 메시징 아키텍처와 다양한 환경에서도 유연한 쿠안타 기술의 핵심 기능에 대해 알아보세요.",
-      "cta": "Learn"
+      "description": "변동성이 큰 시장에서도 안정성과 우수한 기술력을 갖춘 단일 메시징 아키텍처와 다양한 환경에 유연한 쿠안타 기술의 핵심 기능을 확인해 보세요.",
+      "cta": "자세히 알아보기"
     },
     "footer": {
       "companyName": "㈜빌리크루",
@@ -102,7 +102,7 @@
       "brand": "Kuanta",
       "address": "서울특별시 영등포구 국제금융2길 17, 6층 608호 (여의도동, 시티플라자)",
       "businessRegistrationNumber": "678-87-02665",
-      "rights": "© billycrew 2023. All Rights Reserved.",
+      "rights": "© billycrew 2023. All rights reserved.",
       "top": "TOP ▲"
     }
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,9 @@ import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
+import { FALLBACK_LOCALE, type SupportedLocale } from '../i18n';
+
+const locale = (Astro.currentLocale ?? FALLBACK_LOCALE) as SupportedLocale;
 
 import Hero from '../components/home/Hero.astro';
 import Cards from '../components/home/Cards.astro';
@@ -11,7 +14,7 @@ import News from '../components/News.astro';
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={locale}>
   <head>
     <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
   </head>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -3,6 +3,9 @@ import BaseHead from '../../components/BaseHead.astro';
 import Footer from '../../components/Footer.astro';
 import Header from '../../components/Header.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
+import { FALLBACK_LOCALE, type SupportedLocale } from '../../i18n';
+
+const locale = (Astro.currentLocale ?? FALLBACK_LOCALE) as SupportedLocale;
 
 import Hero from '../../components/home/Hero.astro';
 import Cards from '../../components/home/Cards.astro';
@@ -11,7 +14,7 @@ import News from '../../components/News.astro';
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={locale}>
   <head>
     <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
   </head>
@@ -21,7 +24,6 @@ import News from '../../components/News.astro';
     <main>
       <Hero />
       <Cards />
-      <p>BUWHAHAHAHAHAH</p>
       <Features />
       <News />
     </main>

--- a/src/pages/ko/use-cases.astro
+++ b/src/pages/ko/use-cases.astro
@@ -3,36 +3,33 @@ import BaseHead from '../../components/BaseHead.astro';
 import Footer from '../../components/Footer.astro';
 import Header from '../../components/Header.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
+import { FALLBACK_LOCALE, getTranslations, type SupportedLocale } from '../../i18n';
 
+const locale = (Astro.currentLocale ?? FALLBACK_LOCALE) as SupportedLocale;
+const translations = getTranslations(locale);
 const intro = {
-  heading: "POWERED BY",
+  heading: translations.useCases.hero.title,
   heroImg: "/images/use-cases/use-cases-hero.jpg",
 };
 
-const cases = [
+const caseMeta = [
   {
     id: "daishin",
-    titleLines: ["Daishin Securities", "Kuanta Solutions"],
-    desc:
-      "Discover Kuanta’s Features, built with reliable and advanced architecture for volatile markets, offering a consistent single messaging framework and flexible data pipelines.",
     image: "/images/use-cases/daishin.jpg",
-    href: "#",
     reverseOnDesktop: false,
+    content: translations.useCases.case1,
   },
   {
     id: "woori",
-    titleLines: ["WOORI INVESTMENT", "SECURITIES Kuanta", "Solutions"],
-    desc:
-      "Discover Kuanta’s Features, built with reliable and advanced architecture for volatile markets, offering a consistent single messaging framework and flexible data pipelines.",
     image: "/images/use-cases/woori.jpg",
-    href: "#",
     reverseOnDesktop: true,
+    content: translations.useCases.case2,
   },
 ];
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={locale}>
 	<head>
 		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
 	</head>
@@ -41,24 +38,22 @@ const cases = [
     <Header />
 
     <!-- HERO -->
-    <section class="hero" role="img" aria-label="Powered by">
+    <section class="hero" role="img" aria-label={intro.heading}>
       <div class="container"><h1 class="hero__title">{intro.heading}</h1></div>
     </section>
 
     <!-- CASES -->
     <main class="cases">
-      {cases.map((c) => (
+      {caseMeta.map((c) => (
         <section class={"case" + (c.reverseOnDesktop ? " case--reverse" : "")} id={c.id}>
           <figure class="case__media">
-            <img src={c.image} alt={`${c.titleLines[0]} showcase`} />
+            <img src={c.image} alt={`${c.content.title} showcase`} />
           </figure>
 
           <div class="case__content">
-            <h2 class="case__title">
-              {c.titleLines.map((line) => (<span class="case__line">{line}</span>))}
-            </h2>
-            <p class="case__desc">{c.desc}</p>
-            <a href={c.href} class="btn">Learn</a>
+            <h2 class="case__title">{c.content.title}</h2>
+            <p class="case__desc">{c.content.description}</p>
+            <a href="#" class="btn">{c.content.cta}</a>
           </div>
         </section>
       ))}
@@ -151,14 +146,19 @@ const cases = [
     object-fit: cover;
   }
 
-  .case__title{ margin: 0 0 10px; }
-  .case__title .case__line{
-    display: block;
+  .case__title{
+    margin: 0 0 10px;
     background: linear-gradient(90deg, #000C4A 0%, #4A3BFF 95.6%);
     background-clip: text; -webkit-background-clip: text; -webkit-text-fill-color: transparent;
     font-family: "Vitro Core", "Russo One", system-ui, sans-serif;
-    font-size: 36px; font-weight: 900; line-height: 160%; text-transform: capitalize;
+    font-size: clamp(28px, 4vw, 36px);
+    font-weight: 900;
+    line-height: 160%;
     letter-spacing: -0.01em;
+    text-transform: capitalize;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-wrap: balance;
   }
 
   .case__desc{

--- a/src/pages/use-cases.astro
+++ b/src/pages/use-cases.astro
@@ -3,62 +3,57 @@ import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
+import { FALLBACK_LOCALE, getTranslations, type SupportedLocale } from '../i18n';
 
+const locale = (Astro.currentLocale ?? FALLBACK_LOCALE) as SupportedLocale;
+const translations = getTranslations(locale);
 const intro = {
-  heading: "POWERED BY",
+  heading: translations.useCases.hero.title,
   heroImg: "/images/use-cases/use-cases-hero.jpg",
 };
 
-const cases = [
+const caseMeta = [
   {
     id: "daishin",
-    titleLines: ["Daishin Securities", "Kuanta Solutions"],
-    desc:
-      "Discover Kuanta’s Features, built with reliable and advanced architecture for volatile markets, offering a consistent single messaging framework and flexible data pipelines.",
     image: "/images/use-cases/daishin.jpg",
-    href: "#",
     reverseOnDesktop: false,
+    content: translations.useCases.case1,
   },
   {
     id: "woori",
-    titleLines: ["WOORI INVESTMENT", "SECURITIES Kuanta", "Solutions"],
-    desc:
-      "Discover Kuanta’s Features, built with reliable and advanced architecture for volatile markets, offering a consistent single messaging framework and flexible data pipelines.",
     image: "/images/use-cases/woori.jpg",
-    href: "#",
     reverseOnDesktop: true,
+    content: translations.useCases.case2,
   },
 ];
 ---
 
 <!doctype html>
-<html lang="en">
-	<head>
-		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
-	</head>
+<html lang={locale}>
+        <head>
+                <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+        </head>
 
   <body>
     <Header />
 
     <!-- HERO -->
-    <section class="hero" role="img" aria-label="Powered by">
+    <section class="hero" role="img" aria-label={intro.heading}>
       <div class="container"><h1 class="hero__title">{intro.heading}</h1></div>
     </section>
 
     <!-- CASES -->
     <main class="cases">
-      {cases.map((c) => (
+      {caseMeta.map((c) => (
         <section class={"case" + (c.reverseOnDesktop ? " case--reverse" : "")} id={c.id}>
           <figure class="case__media">
-            <img src={c.image} alt={`${c.titleLines[0]} showcase`} />
+            <img src={c.image} alt={`${c.content.title} showcase`} />
           </figure>
 
           <div class="case__content">
-            <h2 class="case__title">
-              {c.titleLines.map((line) => (<span class="case__line">{line}</span>))}
-            </h2>
-            <p class="case__desc">{c.desc}</p>
-            <a href={c.href} class="btn">Learn</a>
+            <h2 class="case__title">{c.content.title}</h2>
+            <p class="case__desc">{c.content.description}</p>
+            <a href="#" class="btn">{c.content.cta}</a>
           </div>
         </section>
       ))}
@@ -151,14 +146,19 @@ const cases = [
     object-fit: cover;
   }
 
-  .case__title{ margin: 0 0 10px; }
-  .case__title .case__line{
-    display: block;
+  .case__title{
+    margin: 0 0 10px;
     background: linear-gradient(90deg, #000C4A 0%, #4A3BFF 95.6%);
     background-clip: text; -webkit-background-clip: text; -webkit-text-fill-color: transparent;
     font-family: "Vitro Core", "Russo One", system-ui, sans-serif;
-    font-size: 36px; font-weight: 900; line-height: 160%; text-transform: capitalize;
+    font-size: clamp(28px, 4vw, 36px);
+    font-weight: 900;
+    line-height: 160%;
     letter-spacing: -0.01em;
+    text-transform: capitalize;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-wrap: balance;
   }
 
   .case__desc{


### PR DESCRIPTION
## Summary
- add a shared translation helper for loading the per-locale JSON dictionaries
- update the header, footer, homepage sections, and use-cases pages to render strings from the active locale
- localize the news section with translated headings, CTAs, and a fallback state when no posts exist

## Testing
- npm run build *(fails: astro CLI not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db12efd6c483309a36b0a7c1aca414